### PR TITLE
remove condition on NODE_ENV

### DIFF
--- a/config/initializers/logging.coffee
+++ b/config/initializers/logging.coffee
@@ -1,16 +1,12 @@
 module.exports = (compound) ->
     console.log = (text) ->
-        if process.env.NODE_ENV is "production"
-            compound.logger.write text
+        compound.logger.write text
 
     console.info = (text) ->
-        if process.env.NODE_ENV is "production"
-            compound.logger.write text
+        compound.logger.write text
 
     console.err = (text) ->
-        if process.env.NODE_ENV is "production"
-            compound.logger.write text
+        compound.logger.write text
 
     console.warn = (text) ->
-        if process.env.NODE_ENV is "production"
-            compound.logger.write text
+        compound.logger.write text


### PR DESCRIPTION
In all case console.log is redefined with compound.logger.write: 

If NODE_ENV = "development", write in shell

If NODE_ENV = "production", write in file log/production.log
