### PR TITLE
Coffee-Script is needed in production so everything can work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "string": "= 1.3.0",
     "axon": "~0.6.1",
     "nodemailer": "= 0.3.31",
-    "cozy-realtime-adapter": "= 0.11.0"
+    "cozy-realtime-adapter": "= 0.11.0",
+    "coffee-script": "latest"
   },
   "devDependencies": {
     "should": ">= 1.2.0",
     "chai": ">= 1.3.0",
     "mocha": ">= 1.6.0",
-    "request": ">= 0",
-    "coffee-script": "latest"
+    "request": ">= 0"
   },
   "main": "server.coffee",
   "scripts": {


### PR DESCRIPTION
This is a temporary change so everything works again. Must be changed next week to:
- build all the JS in a specific folder build/
  - change `cake convert` to `coffee -b --output build/ .`
  - move back the coffee-script dependency to dev-dependencies
  - no more `require "coffee-script/register"`in server.coffee
- in order to make those changes work, we need to move from compound to americano
