### PR TITLE
Increase allowed JSON body-size to 1Gb

### DIFF
--- a/build/server/config.js
+++ b/build/server/config.js
@@ -6,7 +6,9 @@ americano = require('americano');
 config = {
   common: {
     use: [
-      americano.bodyParser(), americano.methodOverride(), americano.errorHandler({
+      americano.bodyParser({
+        limit: '1gb'
+      }), americano.methodOverride(), americano.errorHandler({
         dumpExceptions: true,
         showStack: true
       })

--- a/server/config.coffee
+++ b/server/config.coffee
@@ -3,7 +3,7 @@ americano = require 'americano'
 config =
     common:
         use: [
-            americano.bodyParser()
+            americano.bodyParser limit: '1gb'
             americano.methodOverride()
             americano.errorHandler
                 dumpExceptions: true


### PR DESCRIPTION
Previous limit of JSON document was body-parser default of 100kb, in emails app, we have mail where the html content is bigger than that, so we need to increase this value.
Couchdb max_document_size is 4Gb, 1gb seems to be a good middle ground.
