### PR TITLE
Fixed: the public name emptiness condition was wrong

### DIFF
--- a/build/server/controllers/mails.js
+++ b/build/server/controllers/mails.js
@@ -147,7 +147,7 @@ module.exports.sendFromUser = function(req, res, next) {
         } else {
           domain = 'your.cozy.io';
         }
-        if (((users != null ? (ref1 = users[0]) != null ? ref1.value.public_name : void 0 : void 0) != null) && ((users != null ? (ref2 = users[0]) != null ? ref2.value.public_name : void 0 : void 0) != null) !== '') {
+        if (((users != null ? (ref1 = users[0]) != null ? ref1.value.public_name : void 0 : void 0) != null) && (users != null ? (ref2 = users[0]) != null ? ref2.value.public_name : void 0 : void 0) !== '') {
           displayName = users[0].value.public_name;
           displayName = displayName.toLowerCase().replace(' ', '-');
           displayName += "-";

--- a/build/server/lib/token.js
+++ b/build/server/lib/token.js
@@ -113,6 +113,9 @@ initHomeProxy = function(callback) {
   permissions.home = {
     "application": "authorized",
     "notification": "authorized",
+    "photo": "authorized",
+    "file": "authorized",
+    "binary": "authorized",
     "user": "authorized",
     "device": "authorized",
     "alarm": "authorized",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cozy-data-system",
   "description": "Data-layer between cozy applications and persistence systems",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "author": "Cozy Cloud <contact@cozycloud.cc> (http://cozycloud.cc)",
   "licenses": [
     {

--- a/server/controllers/mails.coffee
+++ b/server/controllers/mails.coffee
@@ -123,7 +123,7 @@ module.exports.sendFromUser = (req, res, next) ->
 
                 # retrieves and slugifies the username if it exists
                 if users?[0]?.value.public_name? and
-                    users?[0]?.value.public_name? isnt ''
+                    users?[0]?.value.public_name isnt ''
                         displayName = users[0].value.public_name
                         displayName = displayName.toLowerCase()
                                                  .replace ' ', '-'

--- a/server/lib/token.coffee
+++ b/server/lib/token.coffee
@@ -115,6 +115,9 @@ initHomeProxy = (callback) ->
     permissions.home =
         "application": "authorized"
         "notification": "authorized"
+        "photo": "authorized"
+        "file": "authorized"
+        "binary": "authorized"
         "user": "authorized"
         "device": "authorized"
         "alarm": "authorized"


### PR DESCRIPTION
If the public name was not set, the sending address was "-noreply@domain.tld", resulting in a "bad sender address" error from postfix.