### PR TITLE
Fix a race condition on locker

### DIFF
--- a/build/server/lib/locker.js
+++ b/build/server/lib/locker.js
@@ -7,13 +7,12 @@ DataLock = (function() {
   }
 
   DataLock.prototype.isLock = function(lock) {
-    return (this.locks[lock] != null) && this.locks[lock];
+    return this.locks[lock] != null;
   };
 
   DataLock.prototype.addLock = function(lock) {
     if (!this.isLock[lock]) {
-      this.locks[lock] = true;
-      return setTimeout((function(_this) {
+      return this.locks[lock] = setTimeout((function(_this) {
         return function() {
           if (_this.isLock(lock)) {
             return delete _this.locks[lock];
@@ -24,7 +23,10 @@ DataLock = (function() {
   };
 
   DataLock.prototype.removeLock = function(lock) {
-    return delete this.locks[lock];
+    if (this.isLock(lock)) {
+      clearTimeout(this.locks[lock]);
+      return delete this.locks[lock];
+    }
   };
 
   DataLock.prototype.runIfUnlock = function(lock, callback) {

--- a/server/lib/locker.coffee
+++ b/server/lib/locker.coffee
@@ -1,30 +1,32 @@
 # Locker needed because of the asynchronous behaviour of nodejs. The same
 # data can be modified by two requests at the same time because node handle
 # both requests without waiting the database response. So with this lock
-# this system, it a data is accessed next request wait until data get free
+# this system, if a data is accessed next request wait until data gets free
 # before being executed.
-# A lock has time to live of 2s
+# A lock has a time to live of 2s
 class DataLock
 
     constructor: ->
         @locks = {}
 
     # True if lock is set.
-    isLock: (lock) -> return @locks[lock]? and @locks[lock]
+    isLock: (lock) -> return @locks[lock]?
 
     # Create a new lock with a 2s TTL
     addLock: (lock) ->
         if not @isLock[lock]
-            @locks[lock] = true
-            setTimeout =>
+            @locks[lock] = setTimeout =>
                 if @isLock lock
                     delete @locks[lock]
             , 2000
 
     # Remove given lock
-    removeLock: (lock) -> delete @locks[lock]
+    removeLock: (lock) ->
+        if @isLock lock
+            clearTimeout @locks[lock]
+            delete @locks[lock]
 
-    # Wait that lock is bein free before running given function
+    # Wait that lock is being free before running given function
     runIfUnlock: (lock, callback) ->
         handleCallback = =>
             if @isLock lock


### PR DESCRIPTION
Before:

- t=0.0s we lock foobar
- t=0.3s we release the foobar lock
- t=1.9s we lock foobar again
- t=2.0s the timeout for the first lock expires and the second lock is released
- t=2.1s a new request for foobar can take the lock even if the second
  request is not yet finished!

After:

When a lock is released, we also clear the timeout associated.