### PR TITLE
Fix decrypting passwords on requests

### DIFF
--- a/server/controllers/requests.coffee
+++ b/server/controllers/requests.coffee
@@ -58,7 +58,7 @@ module.exports.results = (req, res, next) ->
                         delete value._rev # CouchDB specific, user don't need it
 
                     if value.password? and
-                    not value.docType?.toLowerCase() in ['application', 'user']
+                    not (value.docType?.toLowerCase() in ['application', 'user'])
 
 
                         try


### PR DESCRIPTION
*not* has higher priority than *in* in CoffeeScript, so the condition would get mis-compiled and never triggered, and passwords would remain encrypted.