### PR TITLE
[FIX] Convert binaries

### DIFF
--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -148,7 +148,7 @@ module.exports =
             attachments.remove
             utils.unlockRequest
         ]
-    'data/:id/binaries/convert':
+    'data/:id/binaries/convert/:name':
         get: [
             utils.lockRequest
             utils.getDoc


### PR DESCRIPTION
Allow cozy to correctly play converted binaries.
The name variable in our case is `file`.