### PR TITLE
Encrypt non-password fields

### DIFF
--- a/server/controllers/data.coffee
+++ b/server/controllers/data.coffee
@@ -7,18 +7,26 @@ account = require './accounts'
 
 ## Before and after methods
 
-## Encrypt data in field password
-module.exports.encryptPassword = (req, res, next) ->
+## Encrypt data in field password, and every field which name matches
+## the pattern
+module.exports.encryptFields = (req, res, next) ->
     try
         password = encryption.encrypt req.body.password
     catch error
         return next error
 
     req.body.password = password if password?
+    
+    try
+        req.body = encryption.encryptNeededFields req.body
+    catch error
+        return next error
+        
     next()
 
-# Decrypt data in field password
-module.exports.decryptPassword = (req, res, next) ->
+# Decrypt data in field password, and every field which name matches
+# the pattern
+module.exports.decryptFields = (req, res, next) ->
     try
         password = encryption.decrypt req.doc.password
     catch error
@@ -26,8 +34,13 @@ module.exports.decryptPassword = (req, res, next) ->
         account.addApp req.appName
 
     req.doc.password = password if password?
-    next()
 
+    try
+        req.doc = encryption.decryptNeededFields req.doc
+    catch
+        # Do nothing with the error
+        
+    next()
 
 ## Actions
 

--- a/server/controllers/requests.coffee
+++ b/server/controllers/requests.coffee
@@ -63,7 +63,13 @@ module.exports.results = (req, res, next) ->
                         catch
                             # catch error
                             value._passwordStillEncrypted = true
-
+                    try
+                        for field in Object.keys(value)
+                            if field.match /^encrypted/
+                                value[field] = encryption.decrypt value[field]
+                    catch error
+                        # Do nothing with the error
+                            
                 res.send docs
             else
                 res.send docs

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -27,7 +27,7 @@ module.exports =
     'data/':
         post: [
             utils.checkPermissionsByBody
-            data.encryptPassword
+            data.encryptFields
             data.create
         ]
     'data/search/':
@@ -39,19 +39,19 @@ module.exports =
         get: [
             utils.getDoc
             utils.checkPermissionsByDoc
-            data.decryptPassword
+            data.decryptFields
             data.find
         ]
         post: [
             utils.checkPermissionsByBody
-            data.encryptPassword
+            data.encryptFields
             data.create
         ]
         put: [
             utils.lockRequest
             utils.checkPermissionsByBody
             utils.getDoc
-            data.encryptPassword
+            data.encryptFields
             data.update
             utils.unlockRequest
         ]
@@ -70,7 +70,7 @@ module.exports =
         put: [
             utils.lockRequest
             utils.checkPermissionsByBody
-            data.encryptPassword
+            data.encryptFields
             data.upsert
             utils.unlockRequest
         ]
@@ -80,7 +80,7 @@ module.exports =
             utils.checkPermissionsByBody
             utils.getDoc
             utils.checkPermissionsByDoc
-            data.encryptPassword
+            data.encryptFields
             data.merge
             utils.unlockRequest
         ]

--- a/server/lib/encryption.coffee
+++ b/server/lib/encryption.coffee
@@ -14,7 +14,7 @@ cryptoTools = new CryptoTools()
 slaveKey = null
 day = 24 * 60 * 60 * 1000
 
-encryptionPattern = /^encrypted/
+pattern = /^encrypted/
 
 sendEmail = (mailOptions, callback) ->
     transport = nodemailer.createTransport "SMTP", {}
@@ -117,9 +117,8 @@ exports.encryptNeededFields = (obj) ->
     if obj?
         # Searching for fields to encrypt
         try
-            for field in Object.keys(obj)
-                if field.match encryptionPattern
-                    obj[field] = @encrypt obj[field]
+            obj[field] = @encrypt obj[field] for field in Object.keys(obj) \
+                    when field.match pattern
             return obj
         catch error
             # Error are already logged by the encrypt function
@@ -160,9 +159,8 @@ exports.decryptNeededFields = (obj) ->
     if obj?
         # Searching for fields to decrypt
         try
-            for field in Object.keys(obj)
-                if field.match encryptionPattern
-                    obj[field] = @decrypt obj[field]
+            obj[field] = @decrypt obj[field] for field in Object.keys(obj) \
+                    when field.match pattern
             return obj
         catch error
             # Error are already logged by the decrypt function

--- a/server/lib/encryption.coffee
+++ b/server/lib/encryption.coffee
@@ -14,6 +14,8 @@ cryptoTools = new CryptoTools()
 slaveKey = null
 day = 24 * 60 * 60 * 1000
 
+encryptionPattern = /^encrypted/
+
 sendEmail = (mailOptions, callback) ->
     transport = nodemailer.createTransport "SMTP", {}
     transport.sendMail mailOptions, (error, response) ->
@@ -107,6 +109,27 @@ exports.encrypt = (password) ->
         return password
 
 
+## function encryptNeededFields (obj, callback)
+## @obj {object} object containing fields to decrypt if needed
+## Analyzes an object to determine if some fields need to be encrypted, and
+## proceed to encryption when needed
+exports.encryptNeededFields = (obj) ->
+    if obj?
+        # Searching for fields to encrypt
+        try
+            for field in Object.keys(obj)
+                if field.match encryptionPattern
+                    obj[field] = @encrypt obj[field]
+            return obj
+        catch error
+            # Error are already logged by the encrypt function
+            throw error
+    else
+        err = "object to encrypt doesn't exist"
+        logger.error "[encryptNeededFields]: #{err}"
+        throw error
+
+
 ## function decrypt (password, callback)
 ## @password {string} document password
 ## @callback {function} Continuation to pass control back to when complete.
@@ -127,6 +150,27 @@ exports.decrypt = (password) ->
             throw err
     else
         return password
+
+
+## function decryptNeededFields (obj, callback)
+## @obj {object} object containing fields to decrypt if needed
+## Analyzes an object to determine if some fields need to be decrypted, and
+## proceed to decryption when needed
+exports.decryptNeededFields = (obj) ->
+    if obj?
+        # Searching for fields to decrypt
+        try
+            for field in Object.keys(obj)
+                if field.match encryptionPattern
+                    obj[field] = @decrypt obj[field]
+            return obj
+        catch error
+            # Error are already logged by the decrypt function
+            throw error
+    else
+        err = "object to decrypt doesn't exist"
+        logger.error "[decryptNeededFields]: #{err}"
+        throw err
 
 
 ## function init (password, user, callback)

--- a/server/lib/encryption.coffee
+++ b/server/lib/encryption.coffee
@@ -14,7 +14,7 @@ cryptoTools = new CryptoTools()
 slaveKey = null
 day = 24 * 60 * 60 * 1000
 
-pattern = /^encrypted/
+encryptionPattern = /^encrypted/
 
 sendEmail = (mailOptions, callback) ->
     transport = nodemailer.createTransport "SMTP", {}
@@ -117,8 +117,8 @@ exports.encryptNeededFields = (obj) ->
     if obj?
         # Searching for fields to encrypt
         try
-            obj[field] = @encrypt obj[field] for field in Object.keys(obj) \
-                    when field.match pattern
+            for field in Object.keys(obj) when field.match encryptionPattern
+                obj[field] = @encrypt obj[field]
             return obj
         catch error
             # Error are already logged by the encrypt function
@@ -159,8 +159,8 @@ exports.decryptNeededFields = (obj) ->
     if obj?
         # Searching for fields to decrypt
         try
-            obj[field] = @decrypt obj[field] for field in Object.keys(obj) \
-                    when field.match pattern
+            for field in Object.keys(obj) when field.match encryptionPattern
+                obj[field] = @decrypt obj[field]
             return obj
         catch error
             # Error are already logged by the decrypt function

--- a/tests/encryption_tests.coffee
+++ b/tests/encryption_tests.coffee
@@ -26,6 +26,7 @@ describe "Encryption handling tests", ->
             email: "user@CozyCloud.CC"
             timezone: "Europe/Paris"
             password: "password"
+            encryptedField: "encrypted"
             docType: "User"
         db.save '102', data, done
 
@@ -45,10 +46,12 @@ describe "Encryption handling tests", ->
                     @res = res
                     done()
 
-            it "And I add a document with password", (done)->
+            it "And I add a document with password and encrypted field", \
+                    (done)->
                 data =
                     name: "test"
                     password: "password"
+                    encryptedField: "encrypted"
                 client.post 'data/',data,  (err, res, body) =>
                     @body = body
                     @id = body._id
@@ -57,83 +60,100 @@ describe "Encryption handling tests", ->
             it "Then I recover this document", (done) ->
                 client.get "data/#{@id}/", (err, res, body) =>
                     body.password.should.equal "password"
+                    body.encryptedField.should.equal "encrypted"
                     done()
 
-            it "And password should be encrypted", (done) ->
+            it "And both password and encrypted field should be encrypted", \
+                    (done) ->
                 db.get "#{@id}", (err, body) =>
                     body.password.should.not.equal "password"
+                    body.encryptedField.should.not.equal "encrypted"
                     done()
 
         describe "Update document with password", ->
             before cleanRequest
 
-            it "When I add a document with password", (done) ->
+            it "When I add a document with password and encrypted field", \
+                    (done) ->
                 data =
                     name: "test"
                     password: "password"
+                    encryptedField: "encrypted"
                 client.post 'data/',data,  (err, res, body) =>
                     @body = body
                     @id = body._id
                     done()
 
-            it "And I update the document with a new password", (done) ->
+            it "And I update document with new password and encrypted field", \
+                    (done) ->
                 data =
                     name: "test"
                     password: "new_password"
+                    encryptedField: "new_encrypted"
                 client.put "data/#{@id}/",data,  (err, res, body) =>
                     done()
 
             it "And I recover this document", (done) ->
                 client.get "data/#{@id}/", (err, res, body) =>
                     body.password.should.equal "new_password"
+                    body.encryptedField.should.equal "new_encrypted"
                     done()
 
             it "And password should be encrypted", (done) ->
                 db.get "#{@id}", (err, body) =>
                     body.password.should.not.equal "new_password"
+                    body.encryptedField.should.not.equal "new_encrypted"
                     done()
 
         describe "Merge document with password", ->
             before cleanRequest
 
-            it "When I add a document with password", (done) ->
+            it "When I add a document with password and encrypted field", \
+                    (done) ->
                 data =
                     name: "test"
                     password: "password"
+                    encryptedField: "encrypted"
                 client.post 'data/',data,  (err, res, body) =>
                     @body = body
                     @id = body._id
                     done()
 
-            it "And I merge the document with a new password", (done) ->
+            it "And I merge document with new password and encrypted field", \
+                    (done) ->
                 data =
                     password: "new_password"
+                    encryptedField: "new_encrypted"
                 client.put "data/merge/#{@id}/",data,  (err, res, body) =>
                     done()
 
             it "And I recover this document", (done) ->
                 client.get "data/#{@id}/", (err, res, body) =>
                     body.password.should.equal "new_password"
+                    body.encryptedField.should.equal "new_encrypted"
                     done()
 
             it "And password should be encrypted", (done) ->
                 db.get "#{@id}", (err, body) =>
                     body.password.should.not.equal "new_password"
+                    body.encryptedField.should.not.equal "new_encrypted"
                     done()
 
         describe "Merge document without password", ->
             before cleanRequest
 
-            it "When I add a document with password", (done) ->
+            it "When I add a document with password and encrypted field", \
+                    (done) ->
                 data =
                     name: "test"
                     password: "password"
+                    encryptedField: "encrypted"
                 client.post 'data/', data, (err, res, body) =>
                     @body = body
                     @id = body._id
                     done()
 
-            it "And I merge the document with a new password", (done) ->
+            it "And I merge the document with a new field", (done) ->
                 data =
                     new_field: "new_test"
                 client.put "data/merge/#{@id}/",data,  (err, res, body) =>
@@ -142,17 +162,21 @@ describe "Encryption handling tests", ->
             it "And I recover this document", (done) ->
                 client.get "data/#{@id}/", (err, res, body) =>
                     body.password.should.equal "password"
+                    body.encryptedField.should.equal "encrypted"
                     done()
 
             it "And password should be encrypted", (done) ->
                 db.get "#{@id}", (err, body) =>
                     body.password.should.not.equal "password"
+                    body.encryptedField.should.not.equal "encrypted"
                     done()
 
        describe "Request document with password", ->
             before cleanRequest
 
-            it "When I add a document with password", (done) ->
+            it "When I request a document with password and encrypted field", \
+                    (done) ->
                 client.post '/request/user/all/', {}, (err, res, body) =>
                     body[0].value.password.should.equal "password"
+                    body[0].value.encryptedField.should.equal "encrypted"
                     done()


### PR DESCRIPTION
With addition of 2FA support, we have to think about a way to encrypt fields which name isn't "password". That's because we need to encrypt the 2FA key in the DS, and we can't name the field "password" as such a field already exists for the "User" doctype.

After discussing the matter with @poupotte and @m4dz, we agreed that we should encrypt a field based on wether its name matches a specific pattern. In this pull request, the pattern matches every field which name starts with "encrypted" (the correspondig regular expression being `/^encrypted/`), even for the "User" doctype (which doesn't behave like the others).