### PR TITLE
Make the replications persistent

### DIFF
--- a/server/helpers/db_connect_helper.coffee
+++ b/server/helpers/db_connect_helper.coffee
@@ -11,7 +11,7 @@ initLoginCouch = ->
     lines = S(data.toString('utf8')).lines()
     return lines
 
-setup_credentials = (dbName) ->
+setupCredentials = (dbName) ->
     #default credentials
     credentials = {
         host : process.env.COUCH_HOST or 'localhost',
@@ -36,15 +36,15 @@ replicator = null #replicator connection
 
 exports.db_connect = ->
     if not db?
-        credentials = setup_credentials 'cozy'
+        credentials = setupCredentials 'cozy'
         connection = new cradle.Connection credentials
         db = connection.database credentials.db
 
     return db
 
-exports.dbReplicatorConnect = ->
+exports.db_replicator_connect = ->
     if not replicator?
-        credentials = setup_credentials '_replicator'
+        credentials = setupCredentials '_replicator'
         connection = new cradle.Connection credentials
         replicator = connection.database credentials.db
 

--- a/server/helpers/db_connect_helper.coffee
+++ b/server/helpers/db_connect_helper.coffee
@@ -11,14 +11,14 @@ initLoginCouch = ->
     lines = S(data.toString('utf8')).lines()
     return lines
 
-setup_credentials = ->
+setup_credentials = (dbName) ->
     #default credentials
     credentials = {
         host : process.env.COUCH_HOST or 'localhost',
         port : process.env.COUCH_PORT or '5984',
         cache : false,
         raw: false
-        db: process.env.DB_NAME or 'cozy'
+        db: process.env.DB_NAME or dbName
     }
 
     # credentials retrieved by environment variable
@@ -32,11 +32,20 @@ setup_credentials = ->
     return credentials
 
 db = null #singleton connection
+replicator = null #replicator connection
 
 exports.db_connect = ->
     if not db?
-        credentials = setup_credentials()
+        credentials = setup_credentials 'cozy'
         connection = new cradle.Connection credentials
         db = connection.database credentials.db
 
     return db
+
+exports.db_replicator_connect = ->
+    if not replicator?
+        credentials = setup_credentials '_replicator'
+        connection = new cradle.Connection credentials
+        replicator = connection.database credentials.db
+
+    return replicator

--- a/server/helpers/db_connect_helper.coffee
+++ b/server/helpers/db_connect_helper.coffee
@@ -42,7 +42,7 @@ exports.db_connect = ->
 
     return db
 
-exports.db_replicator_connect = ->
+exports.dbReplicatorConnect = ->
     if not replicator?
         credentials = setup_credentials '_replicator'
         connection = new cradle.Connection credentials

--- a/server/lib/sharing.coffee
+++ b/server/lib/sharing.coffee
@@ -1,5 +1,5 @@
 db = require('../helpers/db_connect_helper').db_connect()
-replicator = require('../helpers/db_connect_helper').dbReplicatorConnect()
+replicator = require('../helpers/db_connect_helper').db_replicator_connect()
 
 async = require 'async'
 request = require 'request-json'

--- a/server/lib/sharing.coffee
+++ b/server/lib/sharing.coffee
@@ -1,5 +1,5 @@
 db = require('../helpers/db_connect_helper').db_connect()
-replicator = require('../helpers/db_connect_helper').db_replicator_connect()
+replicator = require('../helpers/db_connect_helper').dbReplicatorConnect()
 
 async = require 'async'
 request = require 'request-json'


### PR DESCRIPTION
Instead of using the _replicate API, use the _replicator database, which allows to make the replications process persistent, even after a server reboot.
