### PR TITLE
Publish sharing feeds

### DIFF
--- a/server/lib/db_remove_helper.coffee
+++ b/server/lib/db_remove_helper.coffee
@@ -10,6 +10,7 @@ getDeletedDoc = (doc) ->
     _deleted: true
     docType: doc.docType
     binary: doc.binary
+    shareID: doc.shareID
 
 
 # Remove givend document.


### PR DESCRIPTION
Listen for modifications on shared documents, identified by their shareID.
The doc id and shareID are concatenated in one string, and split later in the home. See [here](https://github.com/cozy/cozy-home/pull/765).