### PR TITLE
Fix #237 - race condition in doc feed

### DIFF
--- a/server/lib/feed.coffee
+++ b/server/lib/feed.coffee
@@ -134,11 +134,12 @@ module.exports = class Feed
                 @logger.error err if err
                 doctype = doc?.docType?.toLowerCase()
 
-                @_publish "#{doctype}.#{operation}", doc._id if doctype
-                indexer.onDocumentUpdate doc, change.seq
+                if doctype
+                    @_publish "#{doctype}.#{operation}", doc._id
+                    indexer.onDocumentUpdate doc, change.seq
 
                 # Special case for received shared documents.
-                if doc.shareID? and (doctype isnt 'sharing')
+                if doc?.shareID? and (doctype isnt 'sharing')
                     event = "sharing.#{doctype}.#{operation}"
                     @_publish event, "#{change.id}:#{doc.shareID}"
 


### PR DESCRIPTION
When a document is updated and deleted just after that, the documents feed can got an update and be unable to fetch the document to analyze its update.

@aenario I've made the PR against the master branch. Not sure if it's right, but it's what you have done for #240.