### PR TITLE
Remove last slash in recipient's url

### DIFF
--- a/server/controllers/sharing.coffee
+++ b/server/controllers/sharing.coffee
@@ -105,9 +105,14 @@ module.exports.create = (req, res, next) ->
     # The docType is fixed
     share.docType = "sharing"
 
-    # Generate a preToken for each target
     for target in share.targets
+        # Generate a preToken for each target
         target.preToken = generateToken TOKEN_LENGTH
+        # Remove last slash in recipient's url
+        url = target.recipientUrl
+        if url.charAt(url.length - 1) is '/'
+            target.recipientUrl = url.substring(0, url.length - 1)
+
 
     # save the share document in the database
     db.save share, (err, res) ->


### PR DESCRIPTION
The existence of this slash is badly catch by the [cradle](https://github.com/flatiron/cradle) replication, if a path is added behind.