### PR TITLE
Correclty format the URLs for the sharing

### DIFF
--- a/build/server/controllers/sharing.js
+++ b/build/server/controllers/sharing.js
@@ -72,7 +72,7 @@ saveErrorInTarget = function(error, id, target, callback) {
 };
 
 module.exports.create = function(req, res, next) {
-  var err, j, len, ref, share, target;
+  var err, j, len, ref, share, target, url;
   share = req.body;
   if (utils.hasEmptyField(share, ["targets", "rules"])) {
     err = new Error("Body is incomplete");
@@ -94,6 +94,10 @@ module.exports.create = function(req, res, next) {
   for (j = 0, len = ref.length; j < len; j++) {
     target = ref[j];
     target.preToken = generateToken(TOKEN_LENGTH);
+    url = target.recipientUrl;
+    if (url.charAt(url.length - 1) === '/') {
+      target.recipientUrl = url.substring(0, url.length - 1);
+    }
   }
   return db.save(share, function(err, res) {
     if (err != null) {

--- a/build/server/lib/downloader.js
+++ b/build/server/lib/downloader.js
@@ -71,7 +71,7 @@ module.exports = {
           return releaseStream(res);
         } else if (res.statusCode !== 200) {
           msg = err.message;
-          err = callback(new Error("error occured while downloading attachment " + msg + " "));
+          err = new Error("error occured while downloading attachment " + msg + " ");
           err.status = res.statusCode;
           callback(err);
           return releaseStream(res);

--- a/build/server/lib/feed.js
+++ b/build/server/lib/feed.js
@@ -189,9 +189,9 @@ module.exports = Feed = (function() {
           doctype = doc != null ? (ref = doc.docType) != null ? ref.toLowerCase() : void 0 : void 0;
           if (doctype) {
             _this._publish(doctype + "." + operation, doc._id);
+            indexer.onDocumentUpdate(doc, change.seq);
           }
-          indexer.onDocumentUpdate(doc, change.seq);
-          if ((doc.shareID != null) && (doctype !== 'sharing')) {
+          if (((doc != null ? doc.shareID : void 0) != null) && (doctype !== 'sharing')) {
             event = "sharing." + doctype + "." + operation;
             _this._publish(event, change.id + ":" + doc.shareID);
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cozy-data-system",
   "description": "Data-layer between cozy applications and persistence systems",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "author": "Cozy Cloud <contact@cozycloud.cc> (http://cozycloud.cc)",
   "license": "AGPL-3.0",
   "engines": [

--- a/server/controllers/sharing.coffee
+++ b/server/controllers/sharing.coffee
@@ -108,11 +108,6 @@ module.exports.create = (req, res, next) ->
     for target in share.targets
         # Generate a preToken for each target
         target.preToken = generateToken TOKEN_LENGTH
-        # Remove last slash in recipient's url
-        url = target.recipientUrl
-        if url.charAt(url.length - 1) is '/'
-            target.recipientUrl = url.substring(0, url.length - 1)
-
 
     # save the share document in the database
     db.save share, (err, res) ->

--- a/server/controllers/sharing.coffee
+++ b/server/controllers/sharing.coffee
@@ -105,9 +105,14 @@ module.exports.create = (req, res, next) ->
     # The docType is fixed
     share.docType = "sharing"
 
-    # Generate a preToken for each target
     for target in share.targets
+        # Generate a preToken for each target
         target.preToken = generateToken TOKEN_LENGTH
+        # Remove last slash in recipient's url
+        url = target.recipientUrl
+        if url.charAt(url.length - 1) is '/'
+            target.recipientUrl = url.substring(0, url.length - 1)
+
 
     # save the share document in the database
     db.save share, (err, res) ->

--- a/server/lib/downloader.coffee
+++ b/server/lib/downloader.coffee
@@ -71,7 +71,7 @@ module.exports =
                     releaseStream res
                 else if res.statusCode isnt 200
                     msg = err.message
-                    err = callback new Error """
+                    err = new Error """
                         error occured while downloading attachment #{msg} """
                     err.status = res.statusCode
                     callback err

--- a/server/lib/feed.coffee
+++ b/server/lib/feed.coffee
@@ -134,11 +134,12 @@ module.exports = class Feed
                 @logger.error err if err
                 doctype = doc?.docType?.toLowerCase()
 
-                @_publish "#{doctype}.#{operation}", doc._id if doctype
-                indexer.onDocumentUpdate doc, change.seq
+                if doctype
+                    @_publish "#{doctype}.#{operation}", doc._id
+                    indexer.onDocumentUpdate doc, change.seq
 
                 # Special case for received shared documents.
-                if doc.shareID? and (doctype isnt 'sharing')
+                if doc?.shareID? and (doctype isnt 'sharing')
                     event = "sharing.#{doctype}.#{operation}"
                     @_publish event, "#{change.id}:#{doc.shareID}"
 

--- a/server/lib/sharing.coffee
+++ b/server/lib/sharing.coffee
@@ -132,6 +132,10 @@ module.exports.replicateDocs = (params, callback) ->
         auth = "#{params.id}:#{params.target.token}"
         url = params.target.recipientUrl.replace "://", "://#{auth}@"
 
+        # Remove last slash in recipient's url
+        if url.charAt(url.length - 1) is '/'
+            url = url.substring(0, url.length - 1)
+
         couchCred = db.connection
         couch = [couchCred.host, couchCred.port]
         if couchCred.auth?

--- a/server/lib/sharing.coffee
+++ b/server/lib/sharing.coffee
@@ -10,6 +10,12 @@ user = new User()
 replications = {}
 
 
+# Add https in case the protocol is not specified in the url
+addProtocol = (url) ->
+    url = "https://" + url if url?.indexOf("://") is -1
+    return url
+
+
 # Called each time a change occurs in the _replicator db
 onChange = (change) ->
     if replications[change.id]?
@@ -90,6 +96,9 @@ module.exports.notifyRecipient = (url, path, params, callback) ->
             # Avoid empty usernames
             if not params.sharerName? or (params.sharerName is '')
                 params.sharerName = params.sharerUrl.replace "https://", ""
+
+            # Add https if not specified
+            url = addProtocol url
             # Send to recipient
             remote = request.createClient url
             remote.post path, params, (err, result, body) ->
@@ -111,6 +120,8 @@ module.exports.notifySharer = (url, path, params, callback) ->
 
 # Send a revocation request to the specified url
 module.exports.sendRevocation = (url, path, params, callback) ->
+    # Add https if not specified
+    url = addProtocol url
     remote = request.createClient url
     remote.del path, params, (err, result, body) ->
         handleNotifyResponse err, result, body, callback
@@ -130,7 +141,8 @@ module.exports.replicateDocs = (params, callback) ->
     else
         # Add the credentials in the url
         auth = "#{params.id}:#{params.target.token}"
-        url = params.target.recipientUrl.replace "://", "://#{auth}@"
+        url = addProtocol params.target.recipientUrl
+        url = url.replace "://", "://#{auth}@"
 
         # Remove last slash in recipient's url
         if url.charAt(url.length - 1) is '/'


### PR DESCRIPTION
This cancel a previous modification where the last slash was removed and the url saved in the db. This can cause conflicts after the sharing with applications that save the url with the last slash.
Now, we just check before the existence of this slash before the replication, and remove it if needed.